### PR TITLE
Added JSON ContentType support

### DIFF
--- a/CacheFrontEnd.vb
+++ b/CacheFrontEnd.vb
@@ -147,6 +147,8 @@ Public Class CacheFrontEnd
                 app.Context.Response.Write(CacheString)
                 If app.Context.Request.ServerVariables("REQUEST_URI").ToLower.EndsWith(".xml") Or CacheString.ToLower.StartsWith("<?xml") Then
                     app.Context.Response.ContentType = "application/xml"
+                ElseIf app.Context.Request.ServerVariables("REQUEST_URI").ToLower.EndsWith(".json") Or (CacheString.ToLower.StartsWith("{") And CacheString.ToLower.EndsWith("}")) Then
+                    app.Context.Response.ContentType = "application/json"
                 Else
                     app.Context.Response.ContentType = "text/html"
                 End If


### PR DESCRIPTION
I am using Wordpress also as a JSON API, and this was needed for the cached version of the API response to output correctly. I tried to make a solution which would work for all possible ContentTypes, but couldn't do it, I guess there is a reason detection is written this way ;)